### PR TITLE
Fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ script:
   - vendor/bin/phpunit
 
 after_success:
-    - travis_retry php vendor/bin/coveralls -v
+    - travis_retry php vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "phpunit/phpunit": "<6.0.0",
     "php-vcr/php-vcr": "~1.0",
     "php-vcr/phpunit-testlistener-vcr": "~2.0",
-    "satooshi/php-coveralls": "*"
+    "php-coveralls/php-coveralls": "~2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
https://travis-ci.org/ackintosh/ganesha/jobs/348542995#L601
> $ travis_retry php vendor/bin/coveralls -v
> Could not open input file: vendor/bin/coveralls

In php-coveralls v2, `bin/coveralls` has been renamed to `bin/php-coveralls`.