### PR TITLE
Make guzzle optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,19 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "~6.3",
     "php": ">=5.6.0",
     "psr/http-message": "~1.0"
+  },
+  "suggest": {
+    "guzzlehttp/guzzle": "Allows the usage of the Guzzle Middleware"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7.27",
     "php-vcr/php-vcr": "~1.0",
     "php-vcr/phpunit-testlistener-vcr": "~2.0",
     "php-coveralls/php-coveralls": "~2.0",
-    "predis/predis": "^1.1"
+    "predis/predis": "^1.1",
+    "guzzlehttp/guzzle": "~6.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Since Guzzle is not at the core of this library but a plugin added by the library it should not be required if someone only wants to use the circuit breaker.