### PR TITLE
Bump up php-vcr to 1.4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,6 @@
       "email": "sora.akatsuki@gmail.com"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/morozov/php-vcr"
-    }
-  ],
   "require": {
     "php": ">=7.1.0",
     "psr/http-message": "~1.0"
@@ -29,7 +23,7 @@
   "require-dev": {
     "phpunit/phpunit": "^7.5.19",
     "symfony/yaml": "^3.0|^4.0",
-    "php-vcr/php-vcr": "dev-issues/289 as 1.4.5",
+    "php-vcr/php-vcr": "^1.4.5",
     "php-vcr/phpunit-testlistener-vcr": "~3.2.1",
     "php-coveralls/php-coveralls": "~2.0",
     "predis/predis": "^1.1",


### PR DESCRIPTION
Since https://github.com/php-vcr/php-vcr/pull/293 has been merged, I've removed the workaround that make use of fork and updated php-vcr version.