### PR TITLE
Improve assertEquals and PHPUnit fixtures

### DIFF
--- a/tests/Ackintosh/Ganesha/GuzzleMiddlewareTest.php
+++ b/tests/Ackintosh/Ganesha/GuzzleMiddlewareTest.php
@@ -17,7 +17,7 @@ class GuzzleMiddlewareTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    protected function setUp()
     {
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('No ext-redis present');

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/AbstractRedisTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/AbstractRedisTest.php
@@ -28,7 +28,7 @@ abstract class AbstractRedisTest extends TestCase
      */
     private $configuration;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -170,7 +170,7 @@ abstract class AbstractRedisTest extends TestCase
             $this->redisAdapter->increment($this->service);
             $lastFailureTime = microtime(true);
 
-            $this->assertEquals(
+            $this->assertSame(
                 (int)$lastFailureTime,
                 $this->redisAdapter->loadLastFailureTime($this->service),
                 '',

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/MemcachedTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/MemcachedTest.php
@@ -21,7 +21,7 @@ class MemcachedTest extends TestCase
      */
     private $service = 'testService';
 
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('memcached')) {
             self::markTestSkipped('No ext-memcached present');

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/MongoDBTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/MongoDBTest.php
@@ -31,7 +31,7 @@ class MongoDBTest extends TestCase
     /**
      * @throws \Exception
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Ackintosh/Ganesha/Strategy/RateTest.php
+++ b/tests/Ackintosh/Ganesha/Strategy/RateTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ackintosh\Ganesha;
+namespace Ackintosh\Ganesha\Strategy;
 
 use Ackintosh\Ganesha\Storage\AdapterInterface;
 use Ackintosh\Ganesha\Strategy\Rate;

--- a/tests/Ackintosh/GaneshaTest.php
+++ b/tests/Ackintosh/GaneshaTest.php
@@ -17,7 +17,7 @@ class GaneshaTest extends TestCase
      */
     private $m;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assert equals strict.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/7.5/fixtures.html?highlight=fixtures), it should be the `protected function setUp()` method.
- The `tests/Ackintosh/Ganesha/Strategy/RateTest.php` class namespace should change into `Ackintosh\Ganesha\Strategy;`.