### PR TITLE
Success count now gets cleared when using Redis

### DIFF
--- a/src/Ganesha/Storage/Adapter/Redis.php
+++ b/src/Ganesha/Storage/Adapter/Redis.php
@@ -72,12 +72,6 @@ class Redis implements AdapterInterface, SlidingTimeWindowInterface
      */
     public function load(string $service): int
     {
-        $expires = microtime(true) - $this->configuration->timeWindow();
-
-        if ($this->redis->zRemRangeByScore($service, '-inf', $expires) === false) {
-            throw new StorageException('Failed to remove expired elements. service: ' . $service);
-        }
-
         $r = $this->redis->zCard($service);
 
         if ($r === false) {
@@ -105,6 +99,13 @@ class Redis implements AdapterInterface, SlidingTimeWindowInterface
     public function increment(string $service): void
     {
         $t = microtime(true);
+
+        $expires = $t - $this->configuration->timeWindow();
+
+        if ($this->redis->zRemRangeByScore($service, '-inf', $expires) === false) {
+            throw new StorageException('Failed to remove expired elements. service: ' . $service);
+        }
+
         $this->redis->zAdd($service, $t, $t);
     }
 

--- a/src/Ganesha/Storage/Adapter/Redis.php
+++ b/src/Ganesha/Storage/Adapter/Redis.php
@@ -72,6 +72,8 @@ class Redis implements AdapterInterface, SlidingTimeWindowInterface
      */
     public function load(string $service): int
     {
+        $this->removeExpiredElements($service);
+
         $r = $this->redis->zCard($service);
 
         if ($r === false) {
@@ -100,11 +102,7 @@ class Redis implements AdapterInterface, SlidingTimeWindowInterface
     {
         $t = microtime(true);
 
-        $expires = $t - $this->configuration->timeWindow();
-
-        if ($this->redis->zRemRangeByScore($service, '-inf', $expires) === false) {
-            throw new StorageException('Failed to remove expired elements. service: ' . $service);
-        }
+        $this->removeExpiredElements($service);
 
         $this->redis->zAdd($service, $t, $t);
     }
@@ -178,5 +176,19 @@ class Redis implements AdapterInterface, SlidingTimeWindowInterface
     public function reset(): void
     {
         // TODO: Implement reset() method.
+    }
+
+    /**
+     * @param string $service
+     * 
+     * @throws StorageException
+     */
+    private function removeExpiredElements(string $service): void
+    {
+        $expires = microtime(true) - $this->configuration->timeWindow();
+
+        if ($this->redis->zRemRangeByScore($service, '-inf', $expires) === false) {
+            throw new StorageException('Failed to remove expired elements. service: ' . $service);
+        }
     }
 }

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/AbstractRedisTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/AbstractRedisTest.php
@@ -95,6 +95,20 @@ abstract class AbstractRedisTest extends TestCase
     /**
      * @test
      * @expectedException \Ackintosh\Ganesha\Exception\StorageException
+     * @expectedExceptionMessageRegExp /\AFailed to remove expired elements/
+     */
+    public function incrementThrowsExceptionWhenFailedToRunzRemRangeByScore()
+    {
+        $mock = $this->getMockBuilder(\Redis::class)->getMock();
+        $mock->method('zRemRangeByScore')
+            ->willReturn(false);
+
+        $this->createAdapterWithMock($mock)->increment($this->service);
+    }
+
+    /**
+     * @test
+     * @expectedException \Ackintosh\Ganesha\Exception\StorageException
      * @expectedExceptionMessageRegExp /\AFailed to execute zAdd command/
      */
     public function incrementThrowsExceptionWhenFailedToRunzAdd()
@@ -125,13 +139,13 @@ abstract class AbstractRedisTest extends TestCase
      * @expectedException \Ackintosh\Ganesha\Exception\StorageException
      * @expectedExceptionMessageRegExp /\AFailed to remove expired elements/
      */
-    public function incrementThrowsExceptionWhenFailedToRunzRemRangeByScore()
+    public function loadThrowsExceptionWhenFailedToRunzRemRangeByScore()
     {
         $mock = $this->getMockBuilder(\Redis::class)->getMock();
         $mock->method('zRemRangeByScore')
             ->willReturn(false);
 
-        $this->createAdapterWithMock($mock)->increment($this->service);
+        $this->createAdapterWithMock($mock)->load($this->service);
     }
 
     /**

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/AbstractRedisTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/AbstractRedisTest.php
@@ -125,13 +125,13 @@ abstract class AbstractRedisTest extends TestCase
      * @expectedException \Ackintosh\Ganesha\Exception\StorageException
      * @expectedExceptionMessageRegExp /\AFailed to remove expired elements/
      */
-    public function loadThrowsExceptionWhenFailedToRunzRemRangeByScore()
+    public function incrementThrowsExceptionWhenFailedToRunzRemRangeByScore()
     {
         $mock = $this->getMockBuilder(\Redis::class)->getMock();
         $mock->method('zRemRangeByScore')
             ->willReturn(false);
 
-        $this->createAdapterWithMock($mock)->load($this->service);
+        $this->createAdapterWithMock($mock)->increment($this->service);
     }
 
     /**
@@ -156,7 +156,7 @@ abstract class AbstractRedisTest extends TestCase
     public function loadThrowsException()
     {
         $mock = $this->getMockBuilder(\Redis::class)->getMock();
-        $mock->method('zRemRangeByScore')
+        $mock->method('zCard')
             ->willThrowException(new \RedisException('exception test'));
 
         $this->createAdapterWithMock($mock)->load($this->service);

--- a/tests/Ackintosh/Ganesha/StorageTest.php
+++ b/tests/Ackintosh/Ganesha/StorageTest.php
@@ -44,7 +44,15 @@ class StorageTest extends TestCase
             getenv('GANESHA_EXAMPLE_REDIS') ? getenv('GANESHA_EXAMPLE_REDIS') : 'localhost'
         );
         $r->flushAll();
-        $storage = new Storage(new Redis(($r)), new Ganesha\Storage\StorageKeys(), null);
+
+        $redisAdapter = new Redis($r);
+        $context = new Ganesha\Context(
+            Ganesha\Strategy\Rate::class,
+            $redisAdapter,
+            new Configuration(['timeWindow' => 3])
+        );
+        $redisAdapter->setContext($context);
+        $storage = new Storage($redisAdapter, new Ganesha\Storage\StorageKeys(), null);
 
         $service = 'test';
         $storage->incrementFailureCount($service);


### PR DESCRIPTION
Implemented only for the Redis adapter. Others adapter's methods are empty.

The method gets called everytime `Ganesha::isAvailable()`, which was the wanted behaviour, but [the cleanup wasn't being executed correctly.](https://github.com/ackintosh/ganesha/issues/51#issuecomment-544480379). When called, the method remove those elements in the success keys which were registered before the time set in the `timeWindow()` (so, keys created before **_now_ - _timeWindow_** get removed).

This change, as far as I can tell (correct me if I'm wrong), doesn't break the behaviour, neither the implementations with adapters other than the Redis one.