### PR TITLE
Upgrade Xdebug

### DIFF
--- a/.travis.php.ini
+++ b/.travis.php.ini
@@ -3,3 +3,4 @@ extension="redis.so"
 extension="mongodb.so"
 extension="apcu.so"
 apc.enable_cli=1
+xdebug.mode=coverage

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -10,8 +10,9 @@ if [ $RESULT = 0 ]; then
   yes '' | pecl install redis-5.1.0
   yes '' | pecl install mongodb-1.6.0
   yes '' | pecl install apcu
+else
+  # https://github.com/ackintosh/ganesha/pull/75
+  pecl upgrade xdebug
 fi
-
-pecl upgrade xdebug
 
 phpenv config-add .travis.php.ini

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -12,4 +12,6 @@ if [ $RESULT = 0 ]; then
   yes '' | pecl install apcu
 fi
 
+pecl upgrade xdebug
+
 phpenv config-add .travis.php.ini

--- a/examples/client/Dockerfile
+++ b/examples/client/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update \
  && echo 'extension=memcached.so' >> /usr/local/etc/php/php.ini \
  && yes '' | pecl install redis \
  && echo 'extension=redis.so' >> /usr/local/etc/php/php.ini \
- && yes '' | pecl install xdebug-2.9.0 \
+ && yes '' | pecl install xdebug-3.0.1 \
  && echo 'zend_extension=xdebug.so' >> /usr/local/etc/php/php.ini \
+ && echo 'xdebug.mode=coverage' >> /usr/local/etc/php/php.ini \
  && yes '' | pecl install mongodb \
  && echo 'extension=mongodb.so' >> /usr/local/etc/php/php.ini \
  && yes '' | pecl install apcu \


### PR DESCRIPTION
As mentioned at the [comment](https://github.com/ackintosh/ganesha/pull/69#issuecomment-740208285) , now we get an error on the CI jobs. We should upgrade Xdebug installed on TravisCI (xdebug 3.0.0 -> 3.0.1) to avoid the error.

ref
[0001903: Constants should always be available, regardless of which mode Xdebug is in - MantisBT](https://bugs.xdebug.org/view.php?id=1903)