### PR TITLE
Fix backward incompatibility in v1.2.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           tools: composer
           extensions: apcu, redis, memcached, mongodb
           ini-values: apc.enable_cli=1
+          coverage: xdebug
         env:
           fail-fast: true
 

--- a/src/Ganesha/Storage/Adapter/Apcu.php
+++ b/src/Ganesha/Storage/Adapter/Apcu.php
@@ -51,6 +51,14 @@ class Apcu implements AdapterInterface, TumblingTimeWindowInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function setConfiguration(Configuration $configuration): void
+    {
+        // nop
+    }
+
+    /**
      * @param  string $key
      * @return int
      */

--- a/src/Ganesha/Storage/Adapter/Memcached.php
+++ b/src/Ganesha/Storage/Adapter/Memcached.php
@@ -58,6 +58,14 @@ class Memcached implements AdapterInterface, TumblingTimeWindowInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function setConfiguration(Configuration $configuration): void
+    {
+        // nop
+    }
+
+    /**
      * @param string $service
      * @return int
      * @throws StorageException

--- a/src/Ganesha/Storage/Adapter/MongoDB.php
+++ b/src/Ganesha/Storage/Adapter/MongoDB.php
@@ -65,6 +65,14 @@ class MongoDB implements AdapterInterface, TumblingTimeWindowInterface, SlidingT
     }
 
     /**
+     * @inheritdoc
+     */
+    public function setConfiguration(Configuration $configuration): void
+    {
+        // nop
+    }
+
+    /**
      * @param string $service
      * @return int
      * @throws StorageException

--- a/src/Ganesha/Storage/Adapter/Redis.php
+++ b/src/Ganesha/Storage/Adapter/Redis.php
@@ -57,6 +57,14 @@ class Redis implements AdapterInterface, SlidingTimeWindowInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function setConfiguration(Configuration $configuration): void
+    {
+        // nop
+    }
+
+    /**
      * @param string $service
      *
      * @return int

--- a/src/Ganesha/Storage/AdapterInterface.php
+++ b/src/Ganesha/Storage/AdapterInterface.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ackintosh\Ganesha\Storage;
 
+use Ackintosh\Ganesha\Configuration;
 use Ackintosh\Ganesha\Context;
 
 interface AdapterInterface
@@ -22,6 +23,13 @@ interface AdapterInterface
      * @return void
      */
     public function setContext(Context $context): void;
+
+    /**
+     * @deprecated This param will be removed in the next major release. Please use `setContext` instead.
+     * @param Configuration $configuration
+     * @return void
+     */
+    public function setConfiguration(Configuration $configuration): void;
 
     /**
      * @param  string $service

--- a/src/Ganesha/Storage/AdapterInterface.php
+++ b/src/Ganesha/Storage/AdapterInterface.php
@@ -25,7 +25,7 @@ interface AdapterInterface
     public function setContext(Context $context): void;
 
     /**
-     * @deprecated This param will be removed in the next major release. Please use `setContext` instead.
+     * @deprecated This method will be removed in the next major release. Please use `setContext` instead.
      * @param Configuration $configuration
      * @return void
      */

--- a/src/Ganesha/Traits/BuildGanesha.php
+++ b/src/Ganesha/Traits/BuildGanesha.php
@@ -39,6 +39,9 @@ trait BuildGanesha
 
         $configuration = new Configuration($this->params);
         $context = new Ganesha\Context(self::$strategyClass, $adapter, $configuration);
+
+        // AdapterInterface::setConfiguration() is deprecated since 1.2.2. This will be removed in the next major release.
+        $adapter->setConfiguration($configuration);
         $adapter->setContext($context);
 
         return new Ganesha(self::$strategyClass::create($adapter, $configuration));


### PR DESCRIPTION
related issue: https://github.com/ackintosh/ganesha/issues/80

This fix is to ease the backward incompatibility in [1.2.1](https://github.com/ackintosh/ganesha/releases/tag/1.2.1).

Unfortunately this does not completely fix the incompatibility. If you are using **your custom adapter**, please add `setContext` method like below in order to keep behaviors of your adapter.


If your custom adapter extends a built in adapter like below, it is recommended to use the parent implementation:

```php
class CustomAdapter extends \Ackintosh\Ganesha\Storage\Adapter\Memcached
{
    // Comment out to use the parent implementation
    // public function setContext(Ganesha\Context $context): void
    // {
    // }
}
```

or if your custom adapter using no built in adapter,  please add an empty `setContext` method to satisfy AdapterInterface requirement.

```php
class CustomAdapter implements \Ackintosh\Ganesha\Storage\AdapterInterface
{
    public function setContext(Ganesha\Context $context): void
    {
         // nop
    }
}
```

