### PR TITLE
Check the service is available before record success

### DIFF
--- a/src/Ganesha.php
+++ b/src/Ganesha.php
@@ -84,7 +84,7 @@ class Ganesha
     public function success($service): void
     {
         try {
-            if ($this->strategy->recordSuccess($service) === self::STATUS_CALMED_DOWN) {
+            if ($this->isAvailable($service) && $this->strategy->recordSuccess($service) === self::STATUS_CALMED_DOWN) {
                 $this->notify(self::EVENT_CALMED_DOWN, $service, '');
             }
         } catch (StorageException $e) {


### PR DESCRIPTION
Solve the situation when a request that was sent before the trip may immediately overwrite the success value