### PR TITLE
RedisStore use ClientInterface instead of Client

### DIFF
--- a/src/Ganesha/Storage/Adapter/RedisStore.php
+++ b/src/Ganesha/Storage/Adapter/RedisStore.php
@@ -178,7 +178,7 @@ class RedisStore
     {
         try {
             $result = $this->redis->get($key);
-            if ($this->redis instanceof \Predis\ClientInterface  && $result === null) {
+            if ($this->redis instanceof \Predis\ClientInterface && $result === null) {
                 return false;
             }
             return $result;

--- a/src/Ganesha/Storage/Adapter/RedisStore.php
+++ b/src/Ganesha/Storage/Adapter/RedisStore.php
@@ -8,12 +8,12 @@ use Exception;
 class RedisStore
 {
     /**
-     * @var \Predis\Client|\Redis|\RedisArray|\RedisCluster
+     * @var \Predis\ClientInterface|\Redis|\RedisArray|\RedisCluster
      */
     private $redis;
 
     /**
-     * @param \Redis|\RedisArray|\RedisCluster|\Predis\Client $redisClient
+     * @param \Redis|\RedisArray|\RedisCluster|\Predis\ClientInterface $redisClient
      *
      * @throws \InvalidArgumentException if redis client is not supported
      */
@@ -23,10 +23,10 @@ class RedisStore
             !$redisClient instanceof \Redis
             && !$redisClient instanceof \RedisArray
             && !$redisClient instanceof \RedisCluster
-            && !$redisClient instanceof \Predis\Client
+            && !$redisClient instanceof \Predis\ClientInterface
         ) {
             throw new \InvalidArgumentException(sprintf(
-                '%s() expects parameter 1 to be Redis, RedisArray, RedisCluster or Predis\Client, %s given',
+                '%s() expects parameter 1 to be Redis, RedisArray, RedisCluster, or \Predis\ClientInterface  %s given',
                 __METHOD__,
                 \is_object($redisClient) ? \get_class($redisClient) : \gettype($redisClient)
             ));
@@ -178,7 +178,7 @@ class RedisStore
     {
         try {
             $result = $this->redis->get($key);
-            if ($this->redis instanceof \Predis\Client && $result === null) {
+            if ($this->redis instanceof \Predis\ClientInterface  && $result === null) {
                 return false;
             }
             return $result;

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/PredisRedisClientInterfaceTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/PredisRedisClientInterfaceTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Ackintosh\Ganesha\Storage\Adapter;
+
+use Predis\ClientInterface;
+
+class PredisRedisClientInterfaceTest extends PredisRedisTest
+{
+    protected function getRedisConnection(): ClientInterface
+    {
+        return new PredisRedisClientInterfaceTestDouble(
+            parent::getRedisConnection()
+        );
+    }
+}

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/PredisRedisClientInterfaceTestDouble.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/PredisRedisClientInterfaceTestDouble.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Ackintosh\Ganesha\Storage\Adapter;
+
+use Predis\ClientInterface;
+use Predis\Command\CommandInterface;
+
+final class PredisRedisClientInterfaceTestDouble implements ClientInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProfile()
+    {
+        return $this->client->getProfile();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptions()
+    {
+        return $this->client->getOptions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function connect()
+    {
+        $this->client->connect();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disconnect()
+    {
+        $this->client->disconnect();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection()
+    {
+        return $this->client->getConnection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createCommand($commandID, $arguments = [])
+    {
+        return $this->client->createCommand($commandID, $arguments);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function executeCommand(CommandInterface $command)
+    {
+        return $this->client->executeCommand($command);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __call($commandID, $arguments)
+    {
+        return $this->executeCommand(
+            $this->createCommand($commandID, $arguments)
+        );
+    }
+}

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/PredisRedisTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/PredisRedisTest.php
@@ -3,13 +3,11 @@
 namespace Ackintosh\Ganesha\Storage\Adapter;
 
 use Predis\Client;
+use Predis\ClientInterface;
 
 class PredisRedisTest extends AbstractRedisTest
 {
-    /**
-     * @return Client
-     */
-    protected function getRedisConnection(): Client
+    protected function getRedisConnection(): ClientInterface
     {
         $r = new Client('tcp://' . (getenv('GANESHA_EXAMPLE_REDIS') ?: 'localhost'));
         $r->connect();


### PR DESCRIPTION
We use RedisStore in combination with Predis. We wrap the default client with metric but RedisStore doesn't accept a ClientInterface so we are stuck with passing a Client.

I changed the RedisStore so that it will accept a ClientInterface instead of a Client