### PR TITLE
Update Symfony HttpClient implementation for v6.* and PHP to 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,10 +64,7 @@ jobs:
 
       # https://github.com/php-coveralls/php-coveralls#github-actions
       - name: Upload coverage results to Coveralls
-        # NOTE: For now we would run this step only on php7.4 due to the error on php8.
-        # https://github.com/ackintosh/ganesha/runs/4375377952?check_suite_focus=true
-        # > PHP Fatal error:  Declaration of PhpCoveralls\Bundle\CoverallsBundle\Console\Application::getDefinition() must be compatible with ...
-        if: ${{ matrix.php-version == '7.4' }}
+        if: ${{ matrix.php-version == '8.0' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
-          - "7.4"
           - "8.0"
           - "8.1"
         composer-opts:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5.10",
-    "symfony/http-client": "^4.3|^5.0|^6.0",
+    "symfony/http-client": "^5.3|^6.0",
     "symfony/yaml": "^3.0|^4.0|^5.0|^6.0",
     "php-vcr/php-vcr": "^1.4.5",
     "php-vcr/phpunit-testlistener-vcr": "dev-php8 as 3.2.2",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=7.3.0",
+    "php": ">=8.0",
     "psr/http-message": "~1.0"
   },
   "suggest": {
@@ -29,8 +29,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5.10",
-    "symfony/http-client": "^4.3|^5.0",
-    "symfony/yaml": "^3.0|^4.0|^5.0",
+    "symfony/http-client": "^4.3|^5.0|^6.0",
+    "symfony/yaml": "^3.0|^4.0|^5.0|^6.0",
     "php-vcr/php-vcr": "^1.4.5",
     "php-vcr/phpunit-testlistener-vcr": "dev-php8 as 3.2.2",
     "php-coveralls/php-coveralls": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "symfony/yaml": "^3.0|^4.0|^5.0|^6.0",
     "php-vcr/php-vcr": "^1.4.5",
     "php-vcr/phpunit-testlistener-vcr": "dev-php8 as 3.2.2",
-    "php-coveralls/php-coveralls": "~2.0",
+    "php-coveralls/php-coveralls": "~2.5",
     "predis/predis": "^1.1",
     "guzzlehttp/guzzle": "~6.5",
     "friendsofphp/php-cs-fixer": "^v3.1.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   server:
-    image: php:7.4-apache
+    image: php:8.0-apache
     container_name: server
     volumes:
       - ./examples:/var/www/html

--- a/examples/client/Dockerfile
+++ b/examples/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-cli
+FROM php:8.0-cli
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y git \
@@ -13,7 +13,7 @@ RUN apt-get update \
  && echo 'extension=memcached.so' >> /usr/local/etc/php/php.ini \
  && yes '' | pecl install redis \
  && echo 'extension=redis.so' >> /usr/local/etc/php/php.ini \
- && yes '' | pecl install xdebug-2.9.0 \
+ && yes '' | pecl install xdebug-3.1.5 \
  && echo 'zend_extension=xdebug.so' >> /usr/local/etc/php/php.ini \
  && yes '' | pecl install mongodb \
  && echo 'extension=mongodb.so' >> /usr/local/etc/php/php.ini \

--- a/src/Ganesha/GaneshaHttpClient.php
+++ b/src/Ganesha/GaneshaHttpClient.php
@@ -96,6 +96,9 @@ final class GaneshaHttpClient implements HttpClientInterface
         return $options;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function withOptions(array $options): static
     {
         $clone = clone $this;

--- a/src/Ganesha/GaneshaHttpClient.php
+++ b/src/Ganesha/GaneshaHttpClient.php
@@ -95,4 +95,12 @@ final class GaneshaHttpClient implements HttpClientInterface
 
         return $options;
     }
+
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $this->client->withOptions($options);
+
+        return $clone;
+    }
 }

--- a/tests/Ackintosh/Ganesha/GaneshaHttpClientTest.php
+++ b/tests/Ackintosh/Ganesha/GaneshaHttpClientTest.php
@@ -298,13 +298,16 @@ class GaneshaHttpClientTest extends TestCase
     public function buildWithOptions(): void
     {
         $client = $this->buildClient();
-        $clientWithOptions = $client->withOptions(['headers' => ['Content-Type: text/html']]);
+        // Attach extra data to the request as default.
+        $clientWithOptions = $client->withOptions(['user_data' => 'test']);
 
         $this->assertNotSame($client, $clientWithOptions);
         $this->assertSame(\get_class($client), \get_class($clientWithOptions));
 
         $response = $clientWithOptions->request('GET', 'http://server/server/index.php');
-        $this->assertSame(200, $response->getStatusCode());
+
+        // Test that the extra data can be obtained.
+        $this->assertSame('test', $response->getInfo('user_data'));
     }
 
     /**

--- a/tests/Ackintosh/Ganesha/GaneshaHttpClientTest.php
+++ b/tests/Ackintosh/Ganesha/GaneshaHttpClientTest.php
@@ -293,6 +293,21 @@ class GaneshaHttpClientTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function buildWithOptions(): void
+    {
+        $client = $this->buildClient();
+        $clientWithOptions = $client->withOptions(['headers' => ['Content-Type: text/html']]);
+
+        $this->assertNotSame($client, $clientWithOptions);
+        $this->assertSame(\get_class($client), \get_class($clientWithOptions));
+
+        $response = $clientWithOptions->request('GET', 'http://server/server/index.php');
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /**
      * @param MockResponse[] $responses
      */
     private function buildClient(


### PR DESCRIPTION
Hi !

As of Symfony/HttpClient 5.3, the [withOptions](https://github.com/symfony/http-client/blob/5.3/DecoratorTrait.php#L51) function was [introduced](https://github.com/symfony/http-client/blob/6.1/CHANGELOG.md#53) and it is, therefore, mandatory, if you want to upgrade to the last version of Symfony/HttpClient

Symfony 6 also [requires PHP 8](https://github.com/symfony/symfony/blob/6.0/composer.json#L35) (and for the implementation of the withOptions function with the [static return](https://wiki.php.net/rfc/static_return_type)), I bumped the minimum required version to 8.0. I can go to 8.1 if you prefer, but don't know the other usages of Ganesha (other than HttpClient) and don't want to break anything.

