### PR TITLE
Cast cache expiration in Redis::removeExpiredElements to string

### DIFF
--- a/src/Ganesha/Storage/Adapter/Redis.php
+++ b/src/Ganesha/Storage/Adapter/Redis.php
@@ -185,7 +185,7 @@ class Redis implements AdapterInterface, SlidingTimeWindowInterface
      */
     private function removeExpiredElements(string $service): void
     {
-        $expires = microtime(true) - $this->configuration->timeWindow();
+        $expires = (string)(microtime(true) - $this->configuration->timeWindow());
 
         if ($this->redis->zRemRangeByScore($service, '-inf', $expires) === false) {
             throw new StorageException('Failed to remove expired elements. service: ' . $service);


### PR DESCRIPTION
New version of redis require parameter max to function zRemRangeByScore as string