### PR TITLE
Fix CI error

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           php-version: 8.0
           tools: composer
+          # Specific versions of extensions available on PECL can be set up by suffixing the extension's name with the version.
+          # https://github.com/shivammathur/setup-php?tab=readme-ov-file#heavy_plus_sign-php-extension-support
+          extensions: apcu, redis-5.3.7, memcached, mongodb
         env:
           fail-fast: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,9 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer
-          extensions: apcu, redis, memcached, mongodb
+          # Specific versions of extensions available on PECL can be set up by suffixing the extension's name with the version.
+          # https://github.com/shivammathur/setup-php?tab=readme-ov-file#heavy_plus_sign-php-extension-support
+          extensions: apcu, redis-5.3.7, memcached, mongodb
           ini-values: apc.enable_cli=1
           coverage: xdebug
         env:


### PR DESCRIPTION
Currently the CI workflow fails with the message:

https://github.com/ackintosh/ganesha/actions/runs/8258393210/job/22590548279?pr=111
>   Problem 1
>    - Root composer.json requires PHP extension ext-redis ~5.1 but it has the wrong version installed (6.0.2).