### PR TITLE
Fix example Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       GANESHA_EXAMPLE_REDIS: "redis"
       GANESHA_EXAMPLE_MONGO: "mongo"
       RUN_IN_DOCKER_COMPOSE: 1
+      XDEBUG_MODE: coverage
   memcached:
     image: memcached:1.5.4
     container_name: memcached

--- a/examples/client/Dockerfile
+++ b/examples/client/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
  && echo 'extension=zip.so' >> /usr/local/etc/php/php.ini \
  && yes '' | pecl install memcached \
  && echo 'extension=memcached.so' >> /usr/local/etc/php/php.ini \
- && yes '' | pecl install redis \
+ && yes '' | pecl install redis-5.3.7 \
  && echo 'extension=redis.so' >> /usr/local/etc/php/php.ini \
  && yes '' | pecl install xdebug-3.1.5 \
  && echo 'zend_extension=xdebug.so' >> /usr/local/etc/php/php.ini \

--- a/examples/client/Dockerfile
+++ b/examples/client/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8.0-cli
 
+COPY install_composer.sh /tmp/
+
 RUN apt-get update \
  && apt-get install --no-install-recommends -y git \
  && apt-get install --no-install-recommends -y libmemcached-dev \
@@ -25,9 +27,5 @@ RUN apt-get update \
  && rm -rf /var/cache/apt/* \
  # Install composer
  # https://getcomposer.org/download/
- && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
- && php -r "if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
- && php composer-setup.php \
- && php -r "unlink('composer-setup.php');" \
+ && /tmp/install_composer.sh \
  && mv composer.phar /usr/local/bin/composer
-

--- a/examples/client/install_composer.sh
+++ b/examples/client/install_composer.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
- Fixed failure on docker build for `client` container due to outdated composer install operation.
- Fixed failure on composer install for `client` container due to Redis extension version.
- Added XDEBUG_MODE to enable coverage report.