### PR TITLE
Update Github actions to V4

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -11,7 +11,7 @@ jobs:
     name: Code style check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # https://github.com/shivammathur/setup-php
       - name: Install PHP

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,6 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Lint Code Base
         uses: docker://github/super-linter:v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           - ""
           - --prefer-lowest --prefer-stable
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # https://github.com/shivammathur/setup-php
       - name: Install PHP


### PR DESCRIPTION
Node12 and Node16 are now
depreacted so updating to V4
github actions as that uses Node20

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
