### PR TITLE
feat: pass service name to RejectedException

### DIFF
--- a/src/Ganesha/Exception/RejectedException.php
+++ b/src/Ganesha/Exception/RejectedException.php
@@ -4,4 +4,22 @@ namespace Ackintosh\Ganesha\Exception;
 
 class RejectedException extends \RuntimeException
 {
+    public function __construct(
+        string $message = "",
+        int $code = 0,
+        ?\Throwable $previous = null,
+        private ?string $serviceName = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function withServiceName(string $serviceName): self
+    {
+        return new self(sprintf('"%s" is not available', $serviceName), serviceName: $serviceName);
+    }
+
+    public function serviceName(): ?string
+    {
+        return $this->serviceName;
+    }
 }

--- a/src/Ganesha/GaneshaHttpClient.php
+++ b/src/Ganesha/GaneshaHttpClient.php
@@ -59,7 +59,7 @@ final class GaneshaHttpClient implements HttpClientInterface
         $serviceName = $this->serviceNameExtractor->extract($method, $url, $options);
 
         if (!$this->ganesha->isAvailable($serviceName)) {
-            throw new RejectedException(sprintf('"%s" is not available', $serviceName));
+            throw RejectedException::withServiceName($serviceName);
         }
 
         $response = $this->client->request($method, $url, $this->avoidGaneshaOptionsPropagation($options));

--- a/src/Ganesha/GuzzleMiddleware.php
+++ b/src/Ganesha/GuzzleMiddleware.php
@@ -69,9 +69,7 @@ class GuzzleMiddleware
             if (!$this->ganesha->isAvailable($serviceName)) {
                 return call_user_func(
                     $this->rejectionForFunction,
-                    new RejectedException(
-                        sprintf('"%s" is not available', $serviceName)
-                    )
+                    RejectedException::withServiceName($serviceName),
                 );
             }
 

--- a/tests/Ackintosh/Ganesha/GaneshaHttpClientTest.php
+++ b/tests/Ackintosh/Ganesha/GaneshaHttpClientTest.php
@@ -239,7 +239,7 @@ class GaneshaHttpClientTest extends TestCase
         $ganesha->failure($service);
         $ganesha->failure($service);
 
-        $this->expectException(RejectedException::class);
+        $this->expectExceptionObject(RejectedException::withServiceName($service));
         $client->request('GET', 'http://'.$service.'/awesome_resource');
     }
 

--- a/tests/Ackintosh/Ganesha/GuzzleMiddlewareTest.php
+++ b/tests/Ackintosh/Ganesha/GuzzleMiddlewareTest.php
@@ -155,8 +155,6 @@ class GuzzleMiddlewareTest extends TestCase
      */
     public function reject()
     {
-        $this->expectException(RejectedException::class);
-
         // Build Ganesha which has count strategy with memcached adapter
         $m = new \Memcached();
         $m->addServer(
@@ -179,6 +177,8 @@ class GuzzleMiddlewareTest extends TestCase
         $ganesha->failure($service);
         $ganesha->failure($service);
         $ganesha->failure($service);
+
+        $this->expectExceptionObject(RejectedException::withServiceName($service));
 
         $client->get('http://' . $service . '/awesome_resource');
     }


### PR DESCRIPTION
Adds `serviceName` to `RejectedException`, in a backward compatible way, so it's easier to extract than parsing exception message.

In 4.0 this could be the only public factory method for this exception, I guess.