### PR TITLE
chore: do not fail fast in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         ports:
           - 27017:27017
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "8.0"


### PR DESCRIPTION
As the pipeline seems to suffer from flaky tests, maybe it would be a good idea to let the others tests finish as they mostly prove that everything works 🙈