### PR TITLE
ci: test against `symfony/http-client` 5.3.12 as lowest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,6 @@ jobs:
         composer-opts:
           - ""
           - --prefer-lowest --prefer-stable
-    # We have a dependency issue under the specific condition involving PHP 8.4 and  `--prefer-lowest --prefer-stable`,
-    # so we will allow failure for the condition temporarily.
-    # Dropping the support for EOLed PHP version might resolve this.
-    continue-on-error: ${{ matrix.php-version == '8.4' && matrix.composer-opts == '--prefer-lowest --prefer-stable' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5.10",
-    "symfony/http-client": "^5.3|^6.0",
+    "symfony/http-client": "^5.3.12|^6.0",
     "symfony/yaml": "^3.0|^4.0|^5.0|^6.0",
     "php-vcr/php-vcr": "^1.4.5",
     "php-vcr/phpunit-testlistener-vcr": "dev-php8 as 3.2.2",


### PR DESCRIPTION
This _should_ fix the failing PHP 8.4 pipeline with lowest deps.

I believe we could just drop such outdated packages from composer in general 👀 