### PR TITLE
fix: explicit nullable types

### DIFF
--- a/src/Ganesha/GaneshaHttpClient.php
+++ b/src/Ganesha/GaneshaHttpClient.php
@@ -75,7 +75,7 @@ final class GaneshaHttpClient implements HttpClientInterface
     /**
      * {@inheritdoc}
      */
-    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    public function stream($responses, ?float $timeout = null): ResponseStreamInterface
     {
         return $this->client->stream($responses, $timeout);
     }

--- a/src/Ganesha/GuzzleMiddleware.php
+++ b/src/Ganesha/GuzzleMiddleware.php
@@ -43,8 +43,8 @@ class GuzzleMiddleware
 
     public function __construct(
         Ganesha $ganesha,
-        ServiceNameExtractorInterface $serviceNameExtractor = null,
-        FailureDetectorInterface $failureDetector = null
+        ?ServiceNameExtractorInterface $serviceNameExtractor = null,
+        ?FailureDetectorInterface $failureDetector = null
     ) {
         $this->ganesha = $ganesha;
         $this->serviceNameExtractor = $serviceNameExtractor ?: new ServiceNameExtractor();

--- a/src/Ganesha/Storage.php
+++ b/src/Ganesha/Storage.php
@@ -28,7 +28,7 @@ class Storage
     public function __construct(
         AdapterInterface $adapter,
         StorageKeysInterface $storageKeys,
-        callable $serviceNameDecorator = null
+        ?callable $serviceNameDecorator = null
     ) {
         $this->adapter = $adapter;
         $this->serviceNameDecorator = $serviceNameDecorator;

--- a/src/Ganesha/Storage/Adapter/Apcu.php
+++ b/src/Ganesha/Storage/Adapter/Apcu.php
@@ -19,13 +19,13 @@ class Apcu implements AdapterInterface, TumblingTimeWindowInterface
     /**
      * @param ApcuStore|null $apcuStore Backing store for testing (optional)
      */
-    public function __construct(ApcuStore $apcuStore = null)
+    public function __construct(?ApcuStore $apcuStore = null)
     {
         $this->apcuStore = $apcuStore ?? new ApcuStore();
     }
 
     /**
-     * Returns returns whether the adapter supports counting strategy
+     * Returns whether the adapter supports counting strategy
      */
     public function supportCountStrategy(): bool
     {
@@ -33,7 +33,7 @@ class Apcu implements AdapterInterface, TumblingTimeWindowInterface
     }
 
     /**
-     * Returns returns whether the adapter supports rating strategy
+     * Returns whether the adapter supports rating strategy
      */
     public function supportRateStrategy(): bool
     {

--- a/src/Ganesha/Storage/AdapterInterface.php
+++ b/src/Ganesha/Storage/AdapterInterface.php
@@ -8,12 +8,12 @@ use Ackintosh\Ganesha\Context;
 interface AdapterInterface
 {
     /**
-     * Returns returns whether the adapter supports counting strategy
+     * Returns whether the adapter supports counting strategy
      */
     public function supportCountStrategy(): bool;
 
     /**
-     * Returns returns whether the adapter supports rating strategy
+     * Returns whether the adapter supports rating strategy
      */
     public function supportRateStrategy(): bool;
 

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/ApcuTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/ApcuTest.php
@@ -667,8 +667,8 @@ class ApcuTest extends TestCase
     }
 
     private function getApcu(
-        ApcuStore $apcStore = null,
-        StorageKeysInterface $storageKeys = null
+        ?ApcuStore $apcStore = null,
+        ?StorageKeysInterface $storageKeys = null
     ): Apcu {
         $apc = new Apcu($apcStore);
         $context = new Ganesha\Context(
@@ -680,7 +680,7 @@ class ApcuTest extends TestCase
         return $apc;
     }
 
-    private function getConfiguration(StorageKeysInterface $storageKeys = null)
+    private function getConfiguration(?StorageKeysInterface $storageKeys = null)
     {
         $configuration = $this->createMock(Configuration::class);
         $configuration->method('storageKeys')


### PR DESCRIPTION
Resolves PHP 8.4 deprecation: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated