### PR TITLE
Tweak ext-mongodb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           tools: composer
           # Specific versions of extensions available on PECL can be set up by suffixing the extension's name with the version.
           # https://github.com/shivammathur/setup-php?tab=readme-ov-file#heavy_plus_sign-php-extension-support
-          extensions: apcu, redis-5.3.7, memcached, mongodb
+          extensions: apcu, redis-5.3.7, memcached, mongodb-1.21.0
           ini-values: apc.enable_cli=1
           coverage: xdebug
         env:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "vimeo/psalm" : "*",
     "ext-redis": "~5.1",
     "ext-memcached": "~3.1",
-    "ext-mongodb": ">=1.6"
+    "ext-mongodb": "~1.6"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Currently, in PHP >= 8.3, ext-mongodb v2.0.0 is installed in CI. https://github.com/ackintosh/ganesha/actions/runs/15388129310/job/43304408172