### PR TITLE
Add PHP 8.5 to CI test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         composer-opts:
           - ""
           - --prefer-lowest --prefer-stable


### PR DESCRIPTION
Hello.

I had to verify the compatibility with PHP 8.5, did it in my own fork but here's the CI matrix update here anyway.

All checks green: https://github.com/maksimovic/ganesha/actions/runs/23784003557