### PR TITLE
feat(clock): add support for psr clock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   ],
   "require": {
     "php": "^8.1",
-    "psr/http-message": "^1.0|^2.0"
+    "psr/http-message": "^1.0|^2.0",
+    "psr/clock": "^1.0"
   },
   "suggest": {
     "guzzlehttp/guzzle": "Allows the usage of the Guzzle Middleware",

--- a/src/Ganesha/Configuration.php
+++ b/src/Ganesha/Configuration.php
@@ -60,11 +60,6 @@ class Configuration
         return $this->params[self::STORAGE_KEYS];
     }
 
-    public function clock(): ?ClockInterface
-    {
-        return $this->params[self::CLOCK] ?? null;
-    }
-
     /**
      * @throws \InvalidArgumentException
      */

--- a/src/Ganesha/Configuration.php
+++ b/src/Ganesha/Configuration.php
@@ -5,6 +5,7 @@ namespace Ackintosh\Ganesha;
 use Ackintosh\Ganesha\Storage\AdapterInterface;
 use Ackintosh\Ganesha\Storage\StorageKeys;
 use Ackintosh\Ganesha\Storage\StorageKeysInterface;
+use Psr\Clock\ClockInterface;
 
 class Configuration
 {
@@ -16,6 +17,8 @@ class Configuration
     const MINIMUM_REQUESTS = 'minimumRequests';
     const INTERVAL_TO_HALF_OPEN = 'intervalToHalfOpen';
     const STORAGE_KEYS = 'storageKeys';
+
+    const CLOCK = 'clock';
 
     private array $params;
 
@@ -55,6 +58,11 @@ class Configuration
     public function storageKeys(): StorageKeysInterface
     {
         return $this->params[self::STORAGE_KEYS];
+    }
+
+    public function clock(): ?ClockInterface
+    {
+        return $this->params[self::CLOCK] ?? null;
     }
 
     /**

--- a/src/Ganesha/NativeClock.php
+++ b/src/Ganesha/NativeClock.php
@@ -7,8 +7,8 @@ use Psr\Clock\ClockInterface;
 
 class NativeClock implements ClockInterface
 {
-	public function now(): DateTimeImmutable
-	{
-		return new DateTimeImmutable();
-	}
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
 }

--- a/src/Ganesha/NativeClock.php
+++ b/src/Ganesha/NativeClock.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ackintosh\Ganesha;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+class NativeClock implements ClockInterface
+{
+	public function now(): DateTimeImmutable
+	{
+		return new DateTimeImmutable();
+	}
+}

--- a/src/Ganesha/Strategy/Count.php
+++ b/src/Ganesha/Strategy/Count.php
@@ -22,23 +22,23 @@ class Count implements StrategyInterface
      */
     private $storage;
 
-	private ClockInterface $clock;
+    private ClockInterface $clock;
 
     private function __construct(
-		Configuration $configuration,
-		Storage $storage,
-		ClockInterface $clock,
-	) {
+        Configuration $configuration,
+        Storage $storage,
+        ClockInterface $clock,
+    ) {
         $this->configuration = $configuration;
         $this->storage = $storage;
-		$this->clock = $clock;
+        $this->clock = $clock;
     }
 
     public static function create(
-		Storage\AdapterInterface $adapter,
-		Configuration $configuration,
-		?ClockInterface $clock = null,
-	): StrategyInterface {
+        Storage\AdapterInterface $adapter,
+        Configuration $configuration,
+        ?ClockInterface $clock = null,
+    ): StrategyInterface {
         return new self(
             $configuration,
             new Storage(
@@ -46,7 +46,7 @@ class Count implements StrategyInterface
                 $configuration->storageKeys(),
                 null
             ),
-			$clock ?? new NativeClock(),
+            $clock ?? new NativeClock(),
         );
     }
 
@@ -107,7 +107,7 @@ class Count implements StrategyInterface
             return false;
         }
 
-		$time = $this->clock->now()->getTimestamp();
+        $time = $this->clock->now()->getTimestamp();
 
         if (($time - $lastFailureTime) > $this->configuration->intervalToHalfOpen()) {
             $this->storage->setFailureCount($service, $this->configuration->failureCountThreshold());

--- a/src/Ganesha/Strategy/Count.php
+++ b/src/Ganesha/Strategy/Count.php
@@ -5,8 +5,10 @@ namespace Ackintosh\Ganesha\Strategy;
 use Ackintosh\Ganesha;
 use Ackintosh\Ganesha\Configuration;
 use Ackintosh\Ganesha\Exception\StorageException;
+use Ackintosh\Ganesha\NativeClock;
 use Ackintosh\Ganesha\Storage;
 use Ackintosh\Ganesha\StrategyInterface;
+use Psr\Clock\ClockInterface;
 
 class Count implements StrategyInterface
 {
@@ -20,27 +22,37 @@ class Count implements StrategyInterface
      */
     private $storage;
 
-    private function __construct(Configuration $configuration, Storage $storage)
-    {
+	private ClockInterface $clock;
+
+    private function __construct(
+		Configuration $configuration,
+		Storage $storage,
+		ClockInterface $clock,
+	) {
         $this->configuration = $configuration;
         $this->storage = $storage;
+		$this->clock = $clock;
     }
 
-    public static function create(Storage\AdapterInterface $adapter, Configuration $configuration): StrategyInterface
-    {
+    public static function create(
+		Storage\AdapterInterface $adapter,
+		Configuration $configuration,
+		?ClockInterface $clock = null,
+	): StrategyInterface {
         return new self(
             $configuration,
             new Storage(
                 $adapter,
                 $configuration->storageKeys(),
                 null
-            )
+            ),
+			$clock ?? new NativeClock(),
         );
     }
 
     public function recordFailure(string $service): int
     {
-        $this->storage->setLastFailureTime($service, time());
+        $this->storage->setLastFailureTime($service, $this->clock->now()->getTimestamp());
         $this->storage->incrementFailureCount($service);
 
         if ($this->storage->getFailureCount($service) >= $this->configuration->failureCountThreshold()
@@ -95,9 +107,11 @@ class Count implements StrategyInterface
             return false;
         }
 
-        if ((time() - $lastFailureTime) > $this->configuration->intervalToHalfOpen()) {
+		$time = $this->clock->now()->getTimestamp();
+
+        if (($time - $lastFailureTime) > $this->configuration->intervalToHalfOpen()) {
             $this->storage->setFailureCount($service, $this->configuration->failureCountThreshold());
-            $this->storage->setLastFailureTime($service, time());
+            $this->storage->setLastFailureTime($service, $time);
             return true;
         }
 

--- a/src/Ganesha/Strategy/Count/Builder.php
+++ b/src/Ganesha/Strategy/Count/Builder.php
@@ -7,6 +7,7 @@ use Ackintosh\Ganesha\Configuration;
 use Ackintosh\Ganesha\Storage\AdapterInterface;
 use Ackintosh\Ganesha\Storage\Adapter\SlidingTimeWindowInterface;
 use Ackintosh\Ganesha\Storage\Adapter\TumblingTimeWindowInterface;
+use Psr\Clock\ClockInterface;
 
 class Builder
 {
@@ -57,6 +58,12 @@ class Builder
     public function storageKeys(Ganesha\Storage\StorageKeysInterface $storageKeys): self
     {
         $this->params[Configuration::STORAGE_KEYS] = $storageKeys;
+        return $this;
+    }
+
+    public function clock(ClockInterface $clock): self
+    {
+        $this->params[Configuration::CLOCK] = $clock;
         return $this;
     }
 }

--- a/src/Ganesha/Strategy/Rate.php
+++ b/src/Ganesha/Strategy/Rate.php
@@ -24,7 +24,7 @@ class Rate implements StrategyInterface
      */
     private $storage;
 
-	private ClockInterface $clock;
+    private ClockInterface $clock;
 
     /**
      * @var array
@@ -41,13 +41,13 @@ class Rate implements StrategyInterface
      * @param Configuration $configuration
      */
     private function __construct(
-		Configuration $configuration,
-		Storage $storage,
-		ClockInterface $clock,
-	) {
+        Configuration $configuration,
+        Storage $storage,
+        ClockInterface $clock,
+    ) {
         $this->configuration = $configuration;
         $this->storage = $storage;
-		$this->clock = $clock;
+        $this->clock = $clock;
     }
 
     /**
@@ -67,11 +67,11 @@ class Rate implements StrategyInterface
     }
 
     public static function create(
-		Storage\AdapterInterface $adapter,
-		Configuration $configuration,
-		?ClockInterface $clock = null
-	): StrategyInterface {
-		$clock = $clock ?? new NativeClock();
+        Storage\AdapterInterface $adapter,
+        Configuration $configuration,
+        ?ClockInterface $clock = null
+    ): StrategyInterface {
+        $clock = $clock ?? new NativeClock();
         $serviceNameDecorator = $adapter instanceof Storage\Adapter\TumblingTimeWindowInterface ? self::serviceNameDecorator($configuration->timeWindow(), $clock) : null;
 
         return new self(
@@ -81,7 +81,7 @@ class Rate implements StrategyInterface
                 $configuration->storageKeys(),
                 $serviceNameDecorator
             ),
-			$clock,
+            $clock,
         );
     }
 
@@ -203,7 +203,7 @@ class Rate implements StrategyInterface
      */
     private function isHalfOpen(string $service): bool
     {
-		$time = $this->clock->now()->getTimestamp();
+        $time = $this->clock->now()->getTimestamp();
 
         if (is_null($lastFailureTime = $this->storage->getLastFailureTime($service))) {
             return false;
@@ -220,7 +220,7 @@ class Rate implements StrategyInterface
     private static function serviceNameDecorator(int $timeWindow, ClockInterface $clock, bool $current = true): \Closure
     {
         return function ($service) use ($timeWindow, $clock, $current) {
-			$time = $clock->now()->getTimestamp();
+            $time = $clock->now()->getTimestamp();
 
             return sprintf(
                 '%s.%d',

--- a/src/Ganesha/Strategy/Rate.php
+++ b/src/Ganesha/Strategy/Rate.php
@@ -5,10 +5,12 @@ namespace Ackintosh\Ganesha\Strategy;
 use Ackintosh\Ganesha;
 use Ackintosh\Ganesha\Configuration;
 use Ackintosh\Ganesha\Exception\StorageException;
+use Ackintosh\Ganesha\NativeClock;
 use Ackintosh\Ganesha\Storage;
 use Ackintosh\Ganesha\StrategyInterface;
 use InvalidArgumentException;
 use LogicException;
+use Psr\Clock\ClockInterface;
 
 class Rate implements StrategyInterface
 {
@@ -21,6 +23,8 @@ class Rate implements StrategyInterface
      * @var Storage
      */
     private $storage;
+
+	private ClockInterface $clock;
 
     /**
      * @var array
@@ -36,10 +40,14 @@ class Rate implements StrategyInterface
     /**
      * @param Configuration $configuration
      */
-    private function __construct(Configuration $configuration, Storage $storage)
-    {
+    private function __construct(
+		Configuration $configuration,
+		Storage $storage,
+		ClockInterface $clock,
+	) {
         $this->configuration = $configuration;
         $this->storage = $storage;
+		$this->clock = $clock;
     }
 
     /**
@@ -58,9 +66,13 @@ class Rate implements StrategyInterface
         }
     }
 
-    public static function create(Storage\AdapterInterface $adapter, Configuration $configuration): StrategyInterface
-    {
-        $serviceNameDecorator = $adapter instanceof Storage\Adapter\TumblingTimeWindowInterface ? self::serviceNameDecorator($configuration->timeWindow()) : null;
+    public static function create(
+		Storage\AdapterInterface $adapter,
+		Configuration $configuration,
+		?ClockInterface $clock = null
+	): StrategyInterface {
+		$clock = $clock ?? new NativeClock();
+        $serviceNameDecorator = $adapter instanceof Storage\Adapter\TumblingTimeWindowInterface ? self::serviceNameDecorator($configuration->timeWindow(), $clock) : null;
 
         return new self(
             $configuration,
@@ -68,13 +80,14 @@ class Rate implements StrategyInterface
                 $adapter,
                 $configuration->storageKeys(),
                 $serviceNameDecorator
-            )
+            ),
+			$clock,
         );
     }
 
     public function recordFailure(string $service): int
     {
-        $this->storage->setLastFailureTime($service, time());
+        $this->storage->setLastFailureTime($service, $this->clock->now()->getTimestamp());
         $this->storage->incrementFailureCount($service);
         if (
             $this->storage->getStatus($service) === Ganesha::STATUS_CALMED_DOWN
@@ -158,7 +171,7 @@ class Rate implements StrategyInterface
 
     private function isClosedInPreviousTimeWindow(string $service): bool
     {
-        $failure = $this->storage->getFailureCountByCustomKey(self::keyForPreviousTimeWindow($service, $this->configuration->timeWindow()));
+        $failure = $this->storage->getFailureCountByCustomKey(self::keyForPreviousTimeWindow($service, $this->configuration->timeWindow(), $this->clock));
         if (
             $failure === 0
             || ($failure / $this->configuration->minimumRequests()) * 100 < $this->configuration->failureRateThreshold()
@@ -166,8 +179,8 @@ class Rate implements StrategyInterface
             return true;
         }
 
-        $success = $this->storage->getSuccessCountByCustomKey(self::keyForPreviousTimeWindow($service, $this->configuration->timeWindow()));
-        $rejection = $this->storage->getRejectionCountByCustomKey(self::keyForPreviousTimeWindow($service, $this->configuration->timeWindow()));
+        $success = $this->storage->getSuccessCountByCustomKey(self::keyForPreviousTimeWindow($service, $this->configuration->timeWindow(), $this->clock));
+        $rejection = $this->storage->getRejectionCountByCustomKey(self::keyForPreviousTimeWindow($service, $this->configuration->timeWindow(), $this->clock));
 
         return $this->isClosedInTimeWindow($failure, $success, $rejection);
     }
@@ -190,32 +203,36 @@ class Rate implements StrategyInterface
      */
     private function isHalfOpen(string $service): bool
     {
+		$time = $this->clock->now()->getTimestamp();
+
         if (is_null($lastFailureTime = $this->storage->getLastFailureTime($service))) {
             return false;
         }
 
-        if ((time() - $lastFailureTime) > $this->configuration->intervalToHalfOpen()) {
-            $this->storage->setLastFailureTime($service, time());
+        if (($time - $lastFailureTime) > $this->configuration->intervalToHalfOpen()) {
+            $this->storage->setLastFailureTime($service, $time);
             return true;
         }
 
         return false;
     }
 
-    private static function serviceNameDecorator(int $timeWindow, $current = true)
+    private static function serviceNameDecorator(int $timeWindow, ClockInterface $clock, bool $current = true): \Closure
     {
-        return function ($service) use ($timeWindow, $current) {
+        return function ($service) use ($timeWindow, $clock, $current) {
+			$time = $clock->now()->getTimestamp();
+
             return sprintf(
                 '%s.%d',
                 $service,
-                $current ? (int)floor(time() / $timeWindow) : (int)floor((time() - $timeWindow) / $timeWindow)
+                $current ? (int)floor($time / $timeWindow) : (int)floor(($time - $timeWindow) / $timeWindow)
             );
         };
     }
 
-    private static function keyForPreviousTimeWindow(string $service, int $timeWindow)
+    private static function keyForPreviousTimeWindow(string $service, int $timeWindow, ClockInterface $clock): string
     {
-        $f = self::serviceNameDecorator($timeWindow, false);
+        $f = self::serviceNameDecorator($timeWindow, $clock, false);
         return $f($service);
     }
 }

--- a/src/Ganesha/Strategy/Rate/Builder.php
+++ b/src/Ganesha/Strategy/Rate/Builder.php
@@ -8,6 +8,7 @@ use Ackintosh\Ganesha\Storage\Adapter\SlidingTimeWindowInterface;
 use Ackintosh\Ganesha\Storage\Adapter\TumblingTimeWindowInterface;
 use Ackintosh\Ganesha\Storage\StorageKeysInterface;
 use Ackintosh\Ganesha\Traits\BuildGanesha;
+use Psr\Clock\ClockInterface;
 
 class Builder
 {
@@ -80,6 +81,12 @@ class Builder
     public function timeWindow(int $timeWindow): self
     {
         $this->params[Configuration::TIME_WINDOW] = $timeWindow;
+        return $this;
+    }
+
+    public function clock(ClockInterface $clock): self
+    {
+        $this->params[Configuration::CLOCK] = $clock;
         return $this;
     }
 }

--- a/src/Ganesha/Traits/BuildGanesha.php
+++ b/src/Ganesha/Traits/BuildGanesha.php
@@ -37,6 +37,8 @@ trait BuildGanesha
         $adapter = $this->params[Configuration::ADAPTER];
         unset($this->params[Configuration::ADAPTER]);
 
+        $clock = $this->params[Configuration::CLOCK] ?? null;
+
         $configuration = new Configuration($this->params);
         $context = new Ganesha\Context(self::$strategyClass, $adapter, $configuration);
 
@@ -44,6 +46,6 @@ trait BuildGanesha
         $adapter->setConfiguration($configuration);
         $adapter->setContext($context);
 
-        return new Ganesha(self::$strategyClass::create($adapter, $configuration));
+        return new Ganesha(self::$strategyClass::create($adapter, $configuration, $clock));
     }
 }

--- a/tests/Ackintosh/Ganesha/Storage/Adapter/MemcachedTest.php
+++ b/tests/Ackintosh/Ganesha/Storage/Adapter/MemcachedTest.php
@@ -424,7 +424,7 @@ class MemcachedTest extends TestCase
 
         $reflection = new \ReflectionMethod(Ganesha\Strategy\Rate::class, 'serviceNameDecorator');
         $reflection->setAccessible(true);
-        $serviceNameDecorator = $reflection->invokeArgs(null, [$timeWindow]);
+        $serviceNameDecorator = $reflection->invokeArgs(null, [$timeWindow, new Ganesha\NativeClock()]);
         $storageKeys = new Ganesha\Storage\StorageKeys();
 
         $successKeyForTheTumblingTimeWindow = $storageKeys->prefix() . $serviceNameDecorator($serviceName) . $storageKeys->success();


### PR DESCRIPTION
This adds support for the [psr/clock](https://www.php-fig.org/psr/psr-20/) instead of relying on the build-in time() function directly.

This allows integrations based on ganesha and project integration/e2e tests to pass in manipulated clocks (symfony/clocks mock clock for example) to more easily manipulate the percieved time of the library and build test without relying on sleep allowing extensive test suites to run a lot quicker.

As this falls back to the added native clock this should introduce any breaking changes.